### PR TITLE
Add lxml to project for regression tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 import os
+from lxml import etree
 
 from flask import Flask
 app = Flask(__name__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask==0.9
 Jinja2==2.6
 gunicorn==0.17.2
+lxml==3.3.5


### PR DESCRIPTION
```
__import__(module)
File "/app/app.py", line 2, in <module>
from lxml import etree
ImportError: /usr/lib/x86_64-linux-gnu/libxml2.so.2: version `LIBXML2_2.9.0' not found (required by /app/.heroku/python/lib/python2.7/site-packages/lxml/etree.so)  
```

  Don't need to actually do anything, just merely importing etree
  from the lxml package will make sure the libxml2 system packages
  are working properly.
